### PR TITLE
Add basic state change listener interface

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/interfaces/OnFastScrollStateChangeListener.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/interfaces/OnFastScrollStateChangeListener.java
@@ -1,0 +1,10 @@
+package com.simplecityapps.recyclerview_fastscroll.interfaces;
+
+public interface OnFastScrollStateChangeListener {
+
+    // Called when fast scrolling begins
+    void onFastScrollStart();
+
+    // Called when fast scrolling ends
+    void onFastScrollStop();
+}

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
@@ -28,6 +28,7 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 
+import com.simplecityapps.recyclerview_fastscroll.interfaces.OnFastScrollStateChangeListener;
 import com.simplecityapps.recyclerview_fastscroll.utils.Utils;
 
 public class FastScrollRecyclerView extends RecyclerView implements RecyclerView.OnItemTouchListener {
@@ -54,6 +55,8 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
     private int mDownX;
     private int mDownY;
     private int mLastY;
+
+    private OnFastScrollStateChangeListener mStateChangeListener;
 
     public FastScrollRecyclerView(Context context) {
         this(context, null);
@@ -109,15 +112,15 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
                 // Keep track of the down positions
                 mDownX = x;
                 mDownY = mLastY = y;
-                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY);
+                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY, mStateChangeListener);
                 break;
             case MotionEvent.ACTION_MOVE:
                 mLastY = y;
-                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY);
+                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY, mStateChangeListener);
                 break;
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
-                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY);
+                mScrollbar.handleTouchEvent(ev, mDownX, mDownY, mLastY, mStateChangeListener);
                 break;
         }
         return mScrollbar.isDragging();
@@ -325,6 +328,10 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
 
     public void setAutoHideEnabled(boolean autoHideEnabled) {
         mScrollbar.setAutoHideEnabled(autoHideEnabled);
+    }
+
+    public void setStateChangeListener(OnFastScrollStateChangeListener stateChangeListener) {
+        mStateChangeListener = stateChangeListener;
     }
 
     public interface SectionedAdapter {

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
@@ -36,6 +36,7 @@ import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 
 import com.simplecityapps.recyclerview_fastscroll.R;
+import com.simplecityapps.recyclerview_fastscroll.interfaces.OnFastScrollStateChangeListener;
 import com.simplecityapps.recyclerview_fastscroll.utils.Utils;
 
 public class FastScroller {
@@ -154,7 +155,8 @@ public class FastScroller {
      * Handles the touch event and determines whether to show the fast scroller (or updates it if
      * it is already showing).
      */
-    public void handleTouchEvent(MotionEvent ev, int downX, int downY, int lastY) {
+    public void handleTouchEvent(MotionEvent ev, int downX, int downY, int lastY,
+                                 OnFastScrollStateChangeListener stateChangeListener) {
         ViewConfiguration config = ViewConfiguration.get(mRecyclerView.getContext());
 
         int action = ev.getAction();
@@ -173,6 +175,9 @@ public class FastScroller {
                     mIsDragging = true;
                     mTouchOffset += (lastY - downY);
                     mPopup.animateVisibility(true);
+                    if (stateChangeListener != null) {
+                        stateChangeListener.onFastScrollStart();
+                    }
                 }
                 if (mIsDragging) {
                     // Update the fastscroller section name at this touch position
@@ -191,6 +196,9 @@ public class FastScroller {
                 if (mIsDragging) {
                     mIsDragging = false;
                     mPopup.animateVisibility(false);
+                    if (stateChangeListener != null) {
+                        stateChangeListener.onFastScrollStop();
+                    }
                 }
                 break;
         }


### PR DESCRIPTION
Add basic fast scroll state listener interface. This only covers `start` and `stop` states for now, but more could be added if necessary.
