### PR TITLE
Rounds popup padding calculation to avoid size changes when the chara…

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollPopup.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollPopup.java
@@ -197,7 +197,7 @@ public class FastScrollPopup {
         if (isVisible()) {
             // Calculate the dimensions and position of the fast scroller popup
             int edgePadding = recyclerView.getScrollBarWidth();
-            int bgPadding = (mBackgroundSize - mTextBounds.height()) / 2;
+            int bgPadding = Math.round((mBackgroundSize - mTextBounds.height()) / 10) * 5;
             int bgHeight = mBackgroundSize;
             int bgWidth = Math.max(mBackgroundSize, mTextBounds.width() + (2 * bgPadding));
             if (mPosition == FastScroller.FastScrollerPopupPosition.CENTER) {


### PR DESCRIPTION
…cter height only differs a few pixels. Fixes #63 

Details: In the default Android Roboto font e.g. alphabetic and numeric characters height sometimes differ only a few pixels. The numbers '1,4,5,6,7' are smaller than '0,2,3,8,9'. This caused the popup width to change its size because the way the horizontal padding gets calculated by getting the vertical padding. I tried different ways to handle this behaviour (e.g. getting the max. font height by FontMetrics). But this did not look well in some situations ('Ä,Ü,Ö' vs 'o,u,n'). So in the end I found simple rounding (to nearest 5) to work best.