### PR TITLE
Thumb color

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
@@ -439,6 +439,10 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
         mStateChangeListener = stateChangeListener;
     }
 
+    public void setThumbInactiveColor(boolean autoHideEnabled) {
+        mScrollbar.setThumbInactiveColor(autoHideEnabled);
+    }
+
     /**
      * Set the FastScroll Popup position. This is either {@link FastScroller.FastScrollerPopupPosition#ADJACENT},
      * meaning the popup moves adjacent to the FastScroll thumb, or {@link FastScroller.FastScrollerPopupPosition#CENTER},

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
@@ -79,6 +79,10 @@ public class FastScroller {
     private boolean mAutoHideEnabled = true;
     private final Runnable mHideRunnable;
 
+    private int mThumbActiveColor;
+    private final int mThumbInactiveColor = 0x79000000;
+    private boolean mThumbInactiveState;
+
     @Retention(SOURCE)
     @IntDef({FastScrollerPopupPosition.ADJACENT, FastScrollerPopupPosition.CENTER})
     public @interface FastScrollerPopupPosition {
@@ -106,9 +110,10 @@ public class FastScroller {
         try {
             mAutoHideEnabled = typedArray.getBoolean(R.styleable.FastScrollRecyclerView_fastScrollAutoHide, true);
             mAutoHideDelay = typedArray.getInteger(R.styleable.FastScrollRecyclerView_fastScrollAutoHideDelay, DEFAULT_AUTO_HIDE_DELAY);
+            mThumbInactiveState = typedArray.getBoolean(R.styleable.FastScrollRecyclerView_fastScrollThumbInactiveColor, false);
+            mThumbActiveColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollThumbColor, 0x79000000);
 
-            int trackColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollTrackColor, 0x1f000000);
-            int thumbColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollThumbColor, 0xff000000);
+            int trackColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollTrackColor, 0x28000000);
             int popupBgColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollPopupBgColor, 0xff000000);
             int popupTextColor = typedArray.getColor(R.styleable.FastScrollRecyclerView_fastScrollPopupTextColor, 0xffffffff);
             int popupTextSize = typedArray.getDimensionPixelSize(R.styleable.FastScrollRecyclerView_fastScrollPopupTextSize, Utils.toScreenPixels(resources, 56));
@@ -116,7 +121,7 @@ public class FastScroller {
             @FastScrollerPopupPosition int popupPosition = typedArray.getInteger(R.styleable.FastScrollRecyclerView_fastScrollPopupPosition, FastScrollerPopupPosition.ADJACENT);
 
             mTrack.setColor(trackColor);
-            mThumb.setColor(thumbColor);
+            mThumb.setColor(mThumbInactiveState ? mThumbInactiveColor : mThumbActiveColor);
             mPopup.setBgColor(popupBgColor);
             mPopup.setTextColor(popupTextColor);
             mPopup.setTextSize(popupTextSize);
@@ -196,6 +201,9 @@ public class FastScroller {
                     if (stateChangeListener != null) {
                         stateChangeListener.onFastScrollStart();
                     }
+                    if (mThumbInactiveState) {
+                        mThumb.setColor(mThumbActiveColor);
+                    }
                 }
                 if (mIsDragging) {
                     // Update the fastscroller section name at this touch position
@@ -217,6 +225,9 @@ public class FastScroller {
                     if (stateChangeListener != null) {
                         stateChangeListener.onFastScrollStop();
                     }
+                }
+                if (mThumbInactiveState) {
+                    mThumb.setColor(mThumbInactiveColor);
                 }
                 break;
         }

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
@@ -384,4 +384,9 @@ public class FastScroller {
     public void setPopupPosition(@FastScrollerPopupPosition int popupPosition) {
         mPopup.setPopupPosition(popupPosition);
     }
+
+    public void setThumbInactiveColor(boolean thumbInactiveColor) {
+        mThumbInactiveState = thumbInactiveColor;
+        mThumb.setColor(mThumbInactiveState ? mThumbInactiveColor : mThumbActiveColor);
+    }
 }

--- a/recyclerview-fastscroll/src/main/res/values/attrs.xml
+++ b/recyclerview-fastscroll/src/main/res/values/attrs.xml
@@ -29,5 +29,6 @@
         </attr>
         <attr name="fastScrollAutoHide" format="reference|boolean" />
         <attr name="fastScrollAutoHideDelay" format="reference|integer" />
+        <attr name="fastScrollThumbInactiveColor" format="reference|boolean" />
     </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
         app:fastScrollPopupTextColor="@android:color/primary_text_dark"
         app:fastScrollPopupTextSize="56sp"
         app:fastScrollThumbColor="@color/colorAccent"
-        app:fastScrollThumbInactiveColor="false"
+        app:fastScrollThumbInactiveColor="true"
         tools:listitem="@layout/item"/>
 
 </FrameLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -34,6 +34,7 @@
         app:fastScrollPopupTextColor="@android:color/primary_text_dark"
         app:fastScrollPopupTextSize="56sp"
         app:fastScrollThumbColor="@color/colorAccent"
+        app:fastScrollThumbInactiveColor="false"
         tools:listitem="@layout/item"/>
 
 </FrameLayout>


### PR DESCRIPTION
… option is disabled by default. Fixes #60

You can enable/disable the thumb to be colored grey while normal scrolling using the `fastScrollThumbInactiveColor` attribute in xml:
```
<com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
         app:fastScrollThumbInactiveColor="true"
         ...
```

Or programmatically via `setThumbInactiveColor(boolean thumbInactiveColor)`