### PR TITLE
Use Canvas.save() to build against API 28

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollPopup.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollPopup.java
@@ -155,7 +155,7 @@ public class FastScrollPopup {
     public void draw(Canvas canvas) {
         if (isVisible()) {
             // Draw the fast scroller popup
-            int restoreCount = canvas.save(Canvas.MATRIX_SAVE_FLAG);
+            int restoreCount = canvas.save();
             canvas.translate(mBgBounds.left, mBgBounds.top);
             mTmpRect.set(mBgBounds);
             mTmpRect.offsetTo(0, 0);


### PR DESCRIPTION
`Canvas.save(int)` was deprecated in API 26 and removed in API 28, so trying to bulid an app against API 28 with this library results in a ProGuard warning that fails the build. See also #88.

Since `Canvas.save()` is equivalent to `Canvas.save(Canvas.MATRIX_SAVE_FLAG | Canvas.CLIP_SAVE_FLAG)` (see their implementation), and the code is not modifying canvas clip, this replacement is totally equivalent.