### PR TITLE
Issue-103 - reverted the mTouchSlop checks as they are not needed for…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,2 +1,2 @@
-#Fri Feb 08 13:50:42 AEDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+#Tue Oct 01 10:48:47 ICT 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/recyclerview-fastscroll/build.gradle
+++ b/recyclerview-fastscroll/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         versionCode 18
-        versionName "2.0.0"
+        versionName "2.0.1-SNAPSHOT"
     }
 
     lintOptions {

--- a/recyclerview-fastscroll/build.gradle
+++ b/recyclerview-fastscroll/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         versionCode 18
-        versionName "2.0.1-SNAPSHOT"
+        versionName "2.0.1"
     }
 
     lintOptions {

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
@@ -88,10 +88,6 @@ public class FastScroller {
     private int mThumbInactiveColor = 0x79000000;
     private boolean mThumbInactiveState;
 
-    private int mTouchSlop;
-
-    private int mLastY;
-
     @Retention(SOURCE)
     @IntDef({PopupTextVerticalAlignmentMode.TEXT_BOUNDS, PopupTextVerticalAlignmentMode.FONT_METRICS})
     public @interface PopupTextVerticalAlignmentMode {
@@ -119,8 +115,6 @@ public class FastScroller {
 
         mThumb = new Paint(Paint.ANTI_ALIAS_FLAG);
         mTrack = new Paint(Paint.ANTI_ALIAS_FLAG);
-
-        mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
 
         TypedArray typedArray = context.getTheme().obtainStyledAttributes(
                 attrs, R.styleable.FastScrollRecyclerView, 0, 0);
@@ -210,8 +204,7 @@ public class FastScroller {
                 break;
             case MotionEvent.ACTION_MOVE:
                 // Check if we should start scrolling
-                if (!mIsDragging && isNearPoint(downX, downY) &&
-                        Math.abs(y - downY) > mTouchSlop) {
+                if (!mIsDragging && isNearPoint(downX, downY)) {
                     mRecyclerView.getParent().requestDisallowInterceptTouchEvent(true);
                     mIsDragging = true;
                     mTouchOffset += (lastY - downY);
@@ -224,8 +217,6 @@ public class FastScroller {
                     }
                 }
                 if (mIsDragging) {
-                    if (mLastY == 0 || Math.abs(mLastY - y) >= mTouchSlop) {
-                        mLastY = y;
                         // Update the fastscroller section name at this touch position
                         boolean layoutManagerReversed = mRecyclerView.isLayoutManagerReversed();
                         int bottom = mRecyclerView.getHeight() - mThumbHeight;
@@ -241,13 +232,11 @@ public class FastScroller {
                         mPopup.setSectionName(sectionName);
                         mPopup.animateVisibility(!sectionName.isEmpty());
                         mRecyclerView.invalidate(mPopup.updateFastScrollerBounds(mRecyclerView, mThumbPosition.y));
-                    }
                 }
                 break;
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
                 mTouchOffset = 0;
-                mLastY = 0;
                 if (mIsDragging) {
                     mIsDragging = false;
                     mPopup.animateVisibility(false);


### PR DESCRIPTION
Fix made for [Issue 103](https://github.com/timusus/RecyclerView-FastScroll/issues/103).

As suggested by @zhanghai `mTouchSlop` is not needed for scroll gestures in dragging, and actually degrades the smoothness of the scrolling