### PR TITLE
The thumb position changes continuously during the view scrolling

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
@@ -230,7 +230,7 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
         // Calculate the current scroll position, the scrollY of the recycler view accounts for the
         // view padding, while the scrollBarY is drawn right up to the background padding (ignoring
         // padding)
-        int scrollY = Math.min(availableScrollHeight, getPaddingTop() + scrolledPastHeight);
+        int scrollY = Math.min(availableScrollHeight, getPaddingTop() + scrolledPastHeight - scrollPosState.rowTopOffset);
 
         int scrollBarY = (int) (((float) scrollY / availableScrollHeight) * availableScrollBarHeight);
         if (isLayoutManagerReversed()) {


### PR DESCRIPTION
In the release version, the thumb does not move until the top item changes and jumps every time a new top item crosses the edge.

Actually the change is a partial rollback of https://github.com/timusus/RecyclerView-FastScroll/commit/7cc13a5d8dbf537ba6b57a3042a7b2737214252e. I did not test how this works with reverse layout, so maybe this requires some extra investigation before merging.